### PR TITLE
renamed a few endpoints

### DIFF
--- a/spatial-api-spec.yaml
+++ b/spatial-api-spec.yaml
@@ -13,14 +13,14 @@ servers:
   - url: 'https://spatial.api.hubmapconsortium.org'
 
 paths:
-  '/db/rebuild/annotation-details':
+  '/rebuild-annotation-details':
     put:
       summary: Rebuild the tables containing the annotation details
       operationId: db_rebuild_annotation_details
       responses:
         '200':
           description: Processed
-  '/samples/extracted-cell-type-counts-from-secondary-analysis-files':
+  '/samples/cell-type-counts':
     put:
       summary: The sample cell type counts are returned by ingest-api
       operationId: samples_extracted_cell_type_counts_from_secondary_analysis_files
@@ -32,21 +32,21 @@ paths:
       responses:
         '202':
           description: Accepted for Processing
-  '/samples/all/reindex':
+  '/samples/reindex-all':
     put:
       summary: For all samples, delete the old sample information and replace it by processing the current data
       operationId: samples_all_reindex
       responses:
         '202':
           description: Accepted for Processing
-  '/samples/sample_uuid/{sample_uuid}/reindex':
+  '/samples/{sample_uuid}/reindex':
     put:
       summary: For the sample_uuid given, delete the old sample information and replace it by processing the current data
       operationId: samples_sample_uuid_reindex
       responses:
         '202':
           description: Accepted for Processing
-  '/samples/organ_code/<organ_code>/reindex':
+  '/samples/organ/<organ_code>/reindex':
     put:
       summary: For all samples associated with the organ_code, delete the old sample information and replace it by processing the current data
       operationId: samples_organ_code_reindex
@@ -110,7 +110,7 @@ paths:
           description: Parameter is incorrect or incorrectly formed
         '404':
           description: No HubMAP IDs were found
-  '/spatial-search/point':
+  '/point-search':
     post:
       summary: List the hubmap_ids associated with the target body that are located within the radius of the point <x, y, z>
       operationId: spatial_search_point


### PR DESCRIPTION
Suggested changes.

Corresponding changes will be needed in the endpoint routes in the actual code before merging this..

Also, I left it alone because it would require larger changes, but I think we should support a single `/search` endpoint with optional arguments instead of the `/search/hubmap-id/{hubmap_id}/radius/{radius}/target/{target}` and `/spatial-search/hubmap-id` endpoints